### PR TITLE
Trivial maintenance to support Verilator >= 4.210

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,7 @@ obj_dir/Vtestbench: $(VERILOGS) sim_main.cpp Makefile
 	$(MAKE) -C obj_dir OPT_FAST="-O2" -f Vtestbench.mk Vtestbench
 
 .PHONY: all
+
+clean:
+	rm -rf obj_dir
+	rm -f log

--- a/cdp1802.v
+++ b/cdp1802.v
@@ -92,7 +92,7 @@ module cdp1802 (
   localparam MEM_RD  = 2'b10;       // memory read strobe
   localparam MEM_WR  = 2'b01;       // memory write strobe
 
-  always @(state, I, N)
+  always @*
     case (state)
     FETCH, BRANCH2, SKIP:           {action, Rwd} = {P, MEM_RD, Rrd + 16'd1};
     EXECUTE, EXECUTE2:

--- a/sim_main.cpp
+++ b/sim_main.cpp
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include "Vtestbench.h"
 #include "verilated_vcd_c.h"
+// This include and the top->rootp syntax are proper for Verilator >= 4.210
+#include "Vtestbench___024root.h"
 
 int main(int argc, char **argv)
 {
@@ -25,7 +27,7 @@ int main(int argc, char **argv)
         fprintf(stderr, "invalid hex value at line %d\n", i + 1);
         exit(1);
       }
-      top->v__DOT___ram__DOT__store[i] = v;
+      top->rootp->v__DOT___ram__DOT__store[i] = v;
     }
 
     FILE *log = fopen("log", "w");

--- a/testbench.v
+++ b/testbench.v
@@ -32,7 +32,7 @@ module testbench (
   wire Q;
   cdp1802 cdp1802 (
     .clock(clock),
-    .resetq(1),
+    .resetq(1'b1),
     .Q(Q),
     .EF(4'b0000),
 


### PR DESCRIPTION
Verilator v4.210 dates to Jul 2021.
If you or your friends are still using versions older than that, LMK and I can rejigger the patch for backwards compatibility based on the recipe in Verilator issue #3343.
To me, that seems like a needless complication, now that it's almost 2025.
